### PR TITLE
chore: bump dependent role versions to latest

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -1,9 +1,9 @@
 ---
 - name: andrewrothstein.unarchivedeps
-  version: 3.0.1
+  version: 3.2.0
 - name: andrewrothstein.kubectl
-  version: v1.3.4
+  version: v1.5.5
 - name: andrewrothstein.argocd
-  version: v1.2.25
+  version: v1.3.3
 - name: bradfordwagner.go-releaser-install
-  version: 1.2.0
+  version: 1.5.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
         tag: '{{ mkcert_version }}'
         separator: '-'
         archive_extension: ''
-        is_binary: True
+        unarchive_format: binary
 
 - include_tasks: install_gtk.yml
 - include_tasks: install_corp_cacert.yml


### PR DESCRIPTION
## Summary
- Bump `meta/requirements.yml` dependent role versions to latest (unarchivedeps 3.0.1->3.2.0, kubectl v1.3.4->v1.5.5, argocd v1.2.25->v1.3.3, go-releaser-install 1.2.0->1.5.0)
- Fix mkcert install to use `unarchive_format: binary` for compatibility with go-releaser-install v1.5.0 (the `is_binary` param was removed upstream)

## Test plan
- [x] container-branches pipeline green on this branch across all OS/arch matrix combinations