### PR TITLE
feat: add ubuntu=resolute (26.04 LTS), remove EOL ubuntu=plucky,questing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,11 +36,7 @@ builds:
       archs:
         - linux/amd64
         - linux/arm64
-    - os: ubuntu_plucky
-      archs:
-        - linux/amd64
-        - linux/arm64
-    - os: ubuntu_questing
+    - os: ubuntu_resolute
       archs:
         - linux/amd64
         - linux/arm64


### PR DESCRIPTION
Track base image OS matrix: add `ubuntu_resolute` (26.04 LTS), remove EOL `ubuntu_plucky` (25.04) + `ubuntu_questing` (25.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)