### PR TITLE
feat: bump upstream ansible -> 6.5.0 (ansible 14.2.0)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,4 +42,4 @@ builds:
         - linux/arm64
 upstream:
     repo: ghcr.io/bradfordwagner/ansible
-    tag: 6.4.0
+    tag: 6.5.0


### PR DESCRIPTION
Update upstream ansible image pin to `6.5.0` (Ansible 14.2.0, base 4.7.0). go-builder also bumps its runtime base pin `4.6.0 -> 4.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)